### PR TITLE
修改对外文档: hbuilderx3.6.2版本后推送获取不到devicetoken的问题。

### DIFF
--- a/JPush_Hbuilder_Demo/manifest.json
+++ b/JPush_Hbuilder_Demo/manifest.json
@@ -15,7 +15,9 @@
             "autoclose" : true,
             "delay" : 0
         },
-        "modules" : {},
+        "modules" : {
+            "Push" : {}
+        },
         /* 模块配置 */
         "distribute" : {
             /* 应用发布信息 */
@@ -50,7 +52,9 @@
             /* ios打包配置 */
             "sdkConfigs" : {
                 "ad" : {},
-                "push" : {},
+                "push" : {
+                    "unipush" : null
+                },
                 "geolocation" : {},
                 "maps" : {}
             }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ const jv = uni.requireNativePlugin('JG-JPushGoogle');
 
 ### 1.2 配置插件
 
-注意：不要勾选uniPush！
+**HBuilderX 3.6.2 及之后版本，请打开mainfest配置文件，选择 App模块配置，勾选 Push 模块。**
+
+**注意：不要勾选uniPush！**
 
 打开 manifest.xml，选中App原生插件配置，选择本地插件，导入 JG-JPushGoogle
 


### PR DESCRIPTION
修改对外文档: hbuilderx3.6.2版本后推送获取不到devicetoken的问题。